### PR TITLE
✨ feat(linting): Disable JSDoc linting rule

### DIFF
--- a/functions/.eslintrc.js
+++ b/functions/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     "quotes": ["error", "double"],
     "import/no-unresolved": 0,
     "indent": ["error", 2],
+    "valid-jsdoc": "off",
   },
   overrides: [
     {


### PR DESCRIPTION
**Disable JSDoc Linting Rule**

This pull request disables the `valid-jsdoc` linting rule in the `.eslintrc.js` file for the `functions` directory. This change is made to allow for more flexibility in writing function documentation, as the JSDoc requirements may not always be necessary or appropriate for the project's needs.