### PR TITLE
borrow-license-scheduler-refactor

### DIFF
--- a/functions/src/schedulers/adobeScheduler.ts
+++ b/functions/src/schedulers/adobeScheduler.ts
@@ -1,5 +1,5 @@
 import {ProgramLicenseID} from "../types/license";
-import {LicenseSchedulerFactory, SchedulerConfig} from "../utils/licenseSchedulerFactory";
+import {LicenseRenewalFactory, SchedulerConfig} from "../utils/licenseSchedulerFactory";
 
 /**
  * Schedules a cron job to borrow an Adobe license every Sunday at midnight.
@@ -10,6 +10,6 @@ const config: SchedulerConfig = {
   cronExpression: "0 0 * * 0",
 };
 
-const scheduler = LicenseSchedulerFactory.getScheduler(config);
+const scheduler = LicenseRenewalFactory.createRenewalScheduler(config);
 
-export const borrowAdobe = scheduler.createScheduler();
+export const borrowAdobe = scheduler.createRenewalTask();

--- a/functions/src/schedulers/foxitScheduler.ts
+++ b/functions/src/schedulers/foxitScheduler.ts
@@ -1,5 +1,5 @@
 import {ProgramLicenseID} from "../types/license";
-import {LicenseSchedulerFactory, SchedulerConfig} from "../utils/licenseSchedulerFactory";
+import {LicenseRenewalFactory, SchedulerConfig} from "../utils/licenseSchedulerFactory";
 
 /**
  * Schedules a cron job to borrow a Foxit license every 3 months on the 1st day at midnight.
@@ -10,5 +10,6 @@ const config: SchedulerConfig = {
   cronExpression: "0 0 1 */3 *",
 };
 
-const scheduler = LicenseSchedulerFactory.getScheduler(config);
-export const borrowFoxit = scheduler.createScheduler();
+const scheduler = LicenseRenewalFactory.createRenewalScheduler(config);
+
+export const borrowFoxit = scheduler.createRenewalTask();

--- a/functions/src/schedulers/zoomScheduler.ts
+++ b/functions/src/schedulers/zoomScheduler.ts
@@ -1,5 +1,5 @@
 import {ProgramLicenseID} from "../types/license";
-import {LicenseSchedulerFactory, SchedulerConfig} from "../utils/licenseSchedulerFactory";
+import {LicenseRenewalFactory, SchedulerConfig} from "../utils/licenseSchedulerFactory";
 
 /**
  * Schedules a cron job to borrow a Zoom license every 4 months on the 1st day at midnight.
@@ -10,5 +10,6 @@ const config: SchedulerConfig = {
   cronExpression: "0 0 1 */4 *",
 };
 
-const scheduler = LicenseSchedulerFactory.getScheduler(config);
-export const borrowZoom = scheduler.createScheduler();
+const scheduler = LicenseRenewalFactory.createRenewalScheduler(config);
+
+export const borrowZoom = scheduler.createRenewalTask();

--- a/functions/src/utils/licenseSchedulerFactory.ts
+++ b/functions/src/utils/licenseSchedulerFactory.ts
@@ -14,47 +14,40 @@ export interface SchedulerConfig {
 }
 
 /**
- * Interface defining the contract for license schedulers
+ * Interface defining the contract for automated license renewal schedulers
  */
-export interface ILicenseScheduler {
+export interface LicenseRenewalScheduler {
   /**
-   * Creates a scheduled function for license management
+   * Creates a scheduled function for automated license renewal
    * @returns {ReturnType<typeof onSchedule>} Firebase scheduled function
    */
-  createScheduler(): ReturnType<typeof onSchedule>;
+  createRenewalTask(): ReturnType<typeof onSchedule>;
 }
 
 /**
- * Abstract factory for creating license schedulers
+ * Factory for creating license renewal schedulers
  */
-export abstract class LicenseSchedulerFactory {
+export class LicenseRenewalFactory {
   /**
-   * Abstract method to create a scheduler
-   * @param {SchedulerConfig} config - Configuration for the scheduler
-   * @returns {ILicenseScheduler} License scheduler instance
-   */
-  abstract createScheduler(config: SchedulerConfig): ILicenseScheduler;
-
-  /**
-   * Creates a new scheduler instance.
+   * Creates a new license renewal scheduler instance
    * @param {SchedulerConfig} config Configuration for the scheduler
-   * @returns {ILicenseScheduler} A new license scheduler instance
+   * @returns {LicenseRenewalScheduler} A new license renewal scheduler instance
    */
-  public static getScheduler(config: SchedulerConfig): ILicenseScheduler {
-    return new DefaultLicenseScheduler(config);
+  public static createRenewalScheduler(config: SchedulerConfig): LicenseRenewalScheduler {
+    return new AutomaticLicenseRenewalScheduler(config);
   }
 }
 
 /**
- * Default implementation of license scheduler
+ * Implementation of automatic license renewal scheduler
  */
-export class DefaultLicenseScheduler implements ILicenseScheduler {
+export class AutomaticLicenseRenewalScheduler implements LicenseRenewalScheduler {
   private readonly programName: string;
   private readonly programLicenseId: ProgramLicenseID;
   private readonly cronExpression: string;
 
   /**
-   * Creates an instance of DefaultLicenseScheduler
+   * Creates an instance of AutomaticLicenseRenewalScheduler
    * @param {SchedulerConfig} config - Configuration for the scheduler
    */
   constructor(config: SchedulerConfig) {
@@ -64,10 +57,10 @@ export class DefaultLicenseScheduler implements ILicenseScheduler {
   }
 
   /**
-   * Creates a scheduled function for license management
+   * Creates a scheduled function for automated license renewal
    * @returns {ReturnType<typeof onSchedule>} Firebase scheduled function
    */
-  public createScheduler() {
+  public createRenewalTask() {
     return onSchedule(this.cronExpression, async () => {
       logger.info(`Starting ${this.programName} license renewal process...`);
 


### PR DESCRIPTION
## Description

This pull request introduces a refactor of the license scheduler functionality in the application. The key changes are:

- Renamed `ILicenseScheduler` interface to `LicenseRenewalScheduler` to better reflect its purpose
- Renamed `DefaultLicenseScheduler` to `AutomaticLicenseRenewalScheduler` for clarity
- Simplified the `LicenseSchedulerFactory` by removing the abstract method and making it a concrete class
- Renamed `createScheduler()` method to `createRenewalTask()` to better describe its purpose
- Migrated the Zoom license scheduler to use the new `LicenseRenewalFactory` instead of the deprecated `LicenseSchedulerFactory`
- Updated the `LicenseSchedulerFactory` to `LicenseRenewalFactory` and renamed the `createScheduler()` method to `createRenewalTask()` to reflect the purpose of the factory

These changes aim to improve the overall design and readability of the license renewal scheduling functionality.

## Changes

<###>
✨ feat(license-renewal): Implement automated license renewal scheduler

This change introduces a new `LicenseRenewalFactory` and `AutomaticLicenseRenewalScheduler` classes to handle the creation and scheduling of automated license renewal tasks.

<###>
🔧 refactor(zoomScheduler): Migrate to new license renewal scheduler

Migrates the Zoom license scheduler to use the new `LicenseRenewalFactory` instead of the deprecated `LicenseSchedulerFactory`.

<###>
✨🔧 refactor(license-scheduler): update license renewal factory

The changes update the `LicenseSchedulerFactory` to `LicenseRenewalFactory` and rename the `createScheduler()` method to `createRenewalTask()`.

<###>
🔧 refactor(adobeScheduler): use LicenseRenewalFactory to create renewal scheduler

The changes update the `adobeScheduler.ts` file to use the `LicenseRenewalFactory` instead of the `LicenseSchedulerFactory` to create the renewal scheduler.