### PR TITLE
✨ feat: Add .firebaserc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ node_modules/
 
 # dataconnect generated files
 .dataconnect
+
+# firebaserc
+.firebaserc


### PR DESCRIPTION
Adds the .firebaserc file to the .gitignore to exclude it from
version control. This file is used to configure the Firebase
project settings and should not be committed to the repository.